### PR TITLE
feat: スマホ版詳細パネルのスクロール時自動展開機能を追加

### DIFF
--- a/src/components/PlaceDetailPanel.tsx
+++ b/src/components/PlaceDetailPanel.tsx
@@ -43,11 +43,18 @@ export default function PlaceDetailPanel() {
   const isTablet = useMediaQuery('(min-width: 768px) and (max-width: 1023px)');
   const isMobile = !isDesktop && !isTablet;
 
-  // タッチイベントハンドラー（スマホ版のみ）
+  // スクロールイベントハンドラー（スマホ版のみ）
   useEffect(() => {
     if (!isMobile || !panelRef.current) return;
 
     const panel = panelRef.current;
+
+    const handleScroll = () => {
+      // スクロールが発生したら自動的に全画面表示に切り替え
+      if (!isExpanded) {
+        setIsExpanded(true);
+      }
+    };
 
     const handleTouchStart = (e: TouchEvent) => {
       startY.current = e.touches[0].clientY;
@@ -71,16 +78,18 @@ export default function PlaceDetailPanel() {
       isDragging.current = false;
     };
 
+    panel.addEventListener('scroll', handleScroll);
     panel.addEventListener('touchstart', handleTouchStart);
     panel.addEventListener('touchmove', handleTouchMove);
     panel.addEventListener('touchend', handleTouchEnd);
 
     return () => {
+      panel.removeEventListener('scroll', handleScroll);
       panel.removeEventListener('touchstart', handleTouchStart);
       panel.removeEventListener('touchmove', handleTouchMove);
       panel.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [isMobile]);
+  }, [isMobile, isExpanded]);
 
   if (!place) return null;
 


### PR DESCRIPTION
- スクロールイベント発生時に自動的に全画面表示に切り替え
- タッチ操作によるスワイプ展開/縮小機能は維持
- アイコンクリックによる手動切り替えも継続サポート
- スマホ版のみで動作する仕様