### PR TITLE
feat: スマホ版詳細パネルのUX改善 v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travel-planner-map",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- パネル内スクロールをなくし、タッチで全画面表示に切り替え
- 展開/縮小ボタンを閉じるボタンに変更
- スマホ版ではボタンを非表示
- プルツーリフレッシュを無効化