### PR TITLE
fix(debug): スクロール展開の超敏感検知とデバッグ表示 v1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.7] - 2024-12-19
+
+### Fixed
+- **スクロール展開機能**: 超敏感な検知とデバッグ表示を追加
+  - タッチ移動の検知感度を1px以上に変更（超敏感設定）
+  - スマホ画面上でのデバッグ情報表示を追加
+  - より詳細なタッチイベントログを実装
+  - タッチイベントが正しく発火しているかを確認可能
+
+### Added
+- **デバッグ機能**: スマホでのタッチ動作確認用
+  - 画面上にリアルタイムデバッグ情報表示
+  - タッチ座標とデルタ値の表示
+  - イベント発火状況の可視化
+
 ## [1.2.6] - 2024-12-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travel-planner-map",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/PlaceDetailPanel.tsx
+++ b/src/components/PlaceDetailPanel.tsx
@@ -22,6 +22,7 @@ export default function PlaceDetailPanel() {
   const [imageModalOpen, setImageModalOpen] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [debugInfo, setDebugInfo] = useState<string>('');
   const panelRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const startY = useRef<number>(0);
@@ -46,20 +47,37 @@ export default function PlaceDetailPanel() {
 
   // スクロール展開のタッチハンドラー
   const handleTouchStart = (e: React.TouchEvent) => {
+    const debugMsg = `TouchStart: mobile=${isMobile}, expanded=${isExpanded}`;
+    console.log(debugMsg);
+    setDebugInfo(debugMsg);
+    
     if (!isMobile || isExpanded) return;
     startY.current = e.touches[0].clientY;
     isDragging.current = false;
+    
+    const startMsg = `Start Y: ${startY.current}`;
+    console.log(startMsg);
+    setDebugInfo(prev => prev + ' | ' + startMsg);
   };
 
   const handleTouchMove = (e: React.TouchEvent) => {
+    const moveMsg = `TouchMove: mobile=${isMobile}, expanded=${isExpanded}`;
+    console.log(moveMsg);
+    
     if (!isMobile || isExpanded) return;
     
     currentY.current = e.touches[0].clientY;
     const deltaY = startY.current - currentY.current;
     
-    // 10px以上の動きで展開
-    if (Math.abs(deltaY) > 10) {
-      console.log('Scroll detected, expanding panel', { deltaY, startY: startY.current, currentY: currentY.current });
+    const detailMsg = `Delta: ${deltaY.toFixed(1)}, Abs: ${Math.abs(deltaY).toFixed(1)}`;
+    console.log(detailMsg);
+    setDebugInfo(`${moveMsg} | ${detailMsg}`);
+    
+    // 1px以上の動きで展開（超敏感設定）
+    if (Math.abs(deltaY) > 1) {
+      const expandMsg = `🚀 EXPANDING! Delta: ${deltaY}`;
+      console.log(expandMsg);
+      setDebugInfo(expandMsg);
       setIsExpanded(true);
     }
   };
@@ -275,6 +293,15 @@ export default function PlaceDetailPanel() {
              <FiX size={20} />
            </button>
          </div>
+         
+         {/* デバッグ情報表示（開発用） */}
+         {isMobile && debugInfo && (
+           <div className="bg-red-100 border border-red-300 rounded mx-4 mb-2 p-2">
+             <p className="text-xs text-red-800 font-mono break-all">
+               DEBUG: {debugInfo}
+             </p>
+           </div>
+         )}
          <div 
            ref={contentRef} 
            className={`${isExpanded ? "overflow-y-auto" : "overflow-hidden"}`}


### PR DESCRIPTION
### 緊急デバッグ対応
- タッチ移動検知感度を1px以上に変更（超敏感設定）
- スマホ画面上にリアルタイムデバッグ情報表示を追加
- タッチ座標とデルタ値の詳細ログ実装

### 確認方法
1. スマホでパネルを表示
2. パネル上部に赤いDEBUGボックスが表示される
3. パネル内をタッチ&ドラッグして情報を確認
4. 1px以上の動きで「 EXPANDING!」が表示されるはず

これで要件を満たさない原因を特定できます。