### PR TITLE
fix(mobile): パネル位置と連続変化のバグ修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.9] - 2024-12-19
+
+### 🐛 バグ修正
+- **モバイル版詳細パネル**: ハンドルバーをドラッグした際にパネルが画面上部へ張り付く問題を修正
+  - `bottom: 0` を常時維持し、ドラッグ中でもパネル下端を基準に高さを連続的に変化させる
+  - 展開状態のみ `top: 0` を付与し、不要な `bottom-0` の重複を排除
+  - クラス名とインラインスタイルの整合性を整理し、位置ズレを解消
+
 ## [1.2.8] - 2024-12-19
 
 ### ✨ 新機能

--- a/src/components/PlaceDetailPanel.tsx
+++ b/src/components/PlaceDetailPanel.tsx
@@ -316,14 +316,12 @@ export default function PlaceDetailPanel() {
     return (
       <div 
         ref={panelRef}
-        className={`fixed left-0 right-0 glass-effect shadow-elevation-5 
+        className={`fixed left-0 right-0 bottom-0 glass-effect shadow-elevation-5 
                    border-t border-system-separator z-50 flex flex-col
                    transition-all duration-300 ease-ios-default
-                   ${isDragActive ? '' : (isExpanded 
-                     ? 'top-0 bottom-0' 
-                     : 'bottom-0 h-[50vh] max-h-[50vh]')}`}
+                   ${isDragActive ? '' : (isExpanded ? 'top-0' : 'h-[50vh] max-h-[50vh]')}`}
         style={{
-          height: isDragActive ? `${panelHeight}vh` : undefined
+          height: isDragActive ? `${panelHeight}vh` : (isExpanded ? '100vh' : undefined)
         }}
              >
          {/* スワイプハンドルと閉じるボタン */}


### PR DESCRIPTION
- bottom: 0 を常時維持し、ドラッグ中の位置ズレを防止
- 展開時のみ top: 0 を適用し連続的な高さ変化を実現
- CHANGELOG に v1.2.9 パッチリリースを追加