### PR TITLE
[v1.2.18] fix(place-detail-panel): ドラッグが途切れる問題をdocumentキャプチャで修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,3 +200,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **モバイル版詳細パネル**: drag 終了時に isDragging が解除されない不具合を修正
   - `useCallback` で touchmove/touchend ハンドラーをメモ化し removeEventListener が機能
   - パネルが再操作不能になる問題を解消 
+
+## [1.2.18] - 2025-07-04
+
+### 🐛 バグ修正
+- **モバイル版詳細パネル**: ハンドルバー外に指が出た瞬間ドラッグが途切れる問題を修正
+  - `touchmove` / `touchend` を `document` キャプチャフェーズに移動し全イベントを捕捉
+  - 上下どちらのドラッグでも連続的にパーセンテージが変化するよう改善 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travel-planner-map",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/PlaceDetailPanel.tsx
+++ b/src/components/PlaceDetailPanel.tsx
@@ -74,9 +74,9 @@ export default function PlaceDetailPanel() {
     console.log(debugMsg);
     setDebugInfo(debugMsg);
 
-    // window にイベントリスナーを追加
-    window.addEventListener('touchmove', handleWindowTouchMove, { passive: false });
-    window.addEventListener('touchend', handleWindowTouchEnd, { passive: false });
+    // ドキュメントレベルでイベントを捕捉 (capture: true で早期取得)
+    document.addEventListener('touchmove', handleWindowTouchMove, { passive: false, capture: true });
+    document.addEventListener('touchend', handleWindowTouchEnd, { passive: false, capture: true });
   };
 
   // Window レベルでのドラッグ処理 (stable reference)
@@ -132,8 +132,8 @@ export default function PlaceDetailPanel() {
     setDebugInfo(finalMsg);
 
     // イベントリスナーを削除
-    window.removeEventListener('touchmove', handleWindowTouchMove);
-    window.removeEventListener('touchend', handleWindowTouchEnd);
+    document.removeEventListener('touchmove', handleWindowTouchMove, { capture: true } as any);
+    document.removeEventListener('touchend', handleWindowTouchEnd, { capture: true } as any);
   }, [handleWindowTouchMove]);
 
   // プルツーリフレッシュ防止（展開状態のみ）
@@ -170,8 +170,8 @@ export default function PlaceDetailPanel() {
   // コンポーネントのアンマウント時にイベントリスナーをクリーンアップ
   useEffect(() => {
     return () => {
-      window.removeEventListener('touchmove', handleWindowTouchMove);
-      window.removeEventListener('touchend', handleWindowTouchEnd);
+      document.removeEventListener('touchmove', handleWindowTouchMove, { capture: true } as any);
+      document.removeEventListener('touchend', handleWindowTouchEnd, { capture: true } as any);
     };
   }, []);
 


### PR DESCRIPTION
- touchmove/touchend を document の capture:true に登録\n- 指がハンドル外に出ても連続ドラッグが持続\n- package.json と CHANGELOG を 1.2.18 に更新