### PR TITLE
Fix invite URL generation by specifying functions region

### DIFF
--- a/env.example
+++ b/env.example
@@ -6,5 +6,8 @@ VITE_FB_STORAGE_BUCKET=
 VITE_FB_MSG_SENDER_ID=
 VITE_FB_APP_ID=
 
+# Functions region (default to us-central1)
+VITE_FB_FUNCTIONS_REGION=
+
 # Google Maps API Key
 VITE_GOOGLE_MAPS_API_KEY= 

--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -3,7 +3,8 @@ import { useDeviceDetect } from '../hooks/useDeviceDetect';
 import Settings from './Settings';
 import SharePlanModal from './SharePlanModal';
 import { usePlanStore } from '../store/planStore';
-import { getFunctions, httpsCallable } from 'firebase/functions';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase';
 import InviteUrlModal from './InviteUrlModal';
 
 const AppMenu: React.FC = () => {
@@ -22,7 +23,6 @@ const AppMenu: React.FC = () => {
     }
 
     try {
-      const functions = getFunctions();
       const inviteUserToPlan = httpsCallable(functions, 'inviteUserToPlan');
       const result = await inviteUserToPlan({ planId: plan.id, email });
       

--- a/src/components/InviteAcceptPage.tsx
+++ b/src/components/InviteAcceptPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { getFunctions, httpsCallable } from 'firebase/functions';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase';
 import { useAuth } from '../hooks/useAuth';
 
 const InviteAcceptPage: React.FC = () => {
@@ -25,7 +26,6 @@ const InviteAcceptPage: React.FC = () => {
       setStatus('pending');
       setMessage('プランに参加しています...');
       try {
-        const functions = getFunctions();
         const acceptInviteToken = httpsCallable(functions, 'acceptInviteToken');
         const result = await acceptInviteToken({ token });
         const data = result.data as { success?: boolean; alreadyMember?: boolean; planId?: string };

--- a/src/components/InviteUrlModal.tsx
+++ b/src/components/InviteUrlModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { getFunctions, httpsCallable } from 'firebase/functions';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase';
 import ModalPortal from './ModalPortal';
 
 interface InviteUrlModalProps {
@@ -20,7 +21,6 @@ const InviteUrlModal: React.FC<InviteUrlModalProps> = ({ isOpen, onClose, planId
     setError(null);
     setCopied(false);
     try {
-      const functions = getFunctions();
       const generateInviteToken = httpsCallable(functions, 'generateInviteToken');
       const result = await generateInviteToken({ planId });
       const data = result.data as { inviteToken: string };

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { enableIndexedDbPersistence, getFirestore } from 'firebase/firestore';
+import { getFunctions } from 'firebase/functions';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FB_API_KEY as string,
@@ -15,6 +16,8 @@ const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+const functionsRegion = (import.meta.env.VITE_FB_FUNCTIONS_REGION as string) || undefined;
+export const functions = getFunctions(app, functionsRegion);
 
 // オフラインキャッシュを有効化（エラーは無視）
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- allow configuring Firebase Functions region via `VITE_FB_FUNCTIONS_REGION`
- expose `functions` instance from `src/firebase.ts`
- update invite components to use the shared `functions` instance

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f50e58bec8332a7162f78acd3da59