### PR TITLE
Fix invite URL generation

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": "22"
+        "node": "20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,13 +6,14 @@ import { v4 as uuidv4 } from 'uuid';
 admin.initializeApp();
 
 const db = admin.firestore();
+const REGION = 'asia-northeast1';
 
 interface InviteData {
   planId: string;
   email: string;
 }
 
-export const inviteUserToPlan = onCall(async (request) => {
+export const inviteUserToPlan = onCall({ region: REGION }, async (request) => {
   // 1. Authentication Check
   if (!request.auth) {
     throw new HttpsError(
@@ -108,7 +109,7 @@ export const inviteUserToPlan = onCall(async (request) => {
  * オーナー/編集者のみ実行可
  * 既存のinviteTokenがあればそれを返し、なければ新規生成
  */
-export const generateInviteToken = onCall(async (request) => {
+export const generateInviteToken = onCall({ region: REGION }, async (request) => {
   if (!request.auth) {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
@@ -140,7 +141,7 @@ export const generateInviteToken = onCall(async (request) => {
  * URL招待トークン受理API
  * トークンから該当プランを検索し、認証済みユーザーをmembersに追加
  */
-export const acceptInviteToken = onCall(async (request) => {
+export const acceptInviteToken = onCall({ region: REGION }, async (request) => {
   if (!request.auth) {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
   </head>
   <body class="h-screen w-screen overflow-hidden">
     <div id="root" class="h-full w-full"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
     
     <!-- NoScript フォールバック -->

--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -22,7 +22,7 @@ const AppMenu: React.FC = () => {
     }
 
     try {
-      const functions = getFunctions();
+      const functions = getFunctions(undefined, 'asia-northeast1');
       const inviteUserToPlan = httpsCallable(functions, 'inviteUserToPlan');
       const result = await inviteUserToPlan({ planId: plan.id, email });
       

--- a/src/components/InviteAcceptPage.tsx
+++ b/src/components/InviteAcceptPage.tsx
@@ -25,7 +25,7 @@ const InviteAcceptPage: React.FC = () => {
       setStatus('pending');
       setMessage('プランに参加しています...');
       try {
-        const functions = getFunctions();
+        const functions = getFunctions(undefined, 'asia-northeast1');
         const acceptInviteToken = httpsCallable(functions, 'acceptInviteToken');
         const result = await acceptInviteToken({ token });
         const data = result.data as { success?: boolean; alreadyMember?: boolean; planId?: string };

--- a/src/components/InviteUrlModal.tsx
+++ b/src/components/InviteUrlModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { getFunctions, httpsCallable } from 'firebase/functions';
+import ModalPortal from './ModalPortal';
 
 interface InviteUrlModalProps {
   isOpen: boolean;
@@ -19,7 +20,7 @@ const InviteUrlModal: React.FC<InviteUrlModalProps> = ({ isOpen, onClose, planId
     setError(null);
     setCopied(false);
     try {
-      const functions = getFunctions();
+      const functions = getFunctions(undefined, 'asia-northeast1');
       const generateInviteToken = httpsCallable(functions, 'generateInviteToken');
       const result = await generateInviteToken({ planId });
       const data = result.data as { inviteToken: string };
@@ -39,7 +40,21 @@ const InviteUrlModal: React.FC<InviteUrlModalProps> = ({ isOpen, onClose, planId
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      setCopied(false);
+      try {
+        const textarea = document.createElement('textarea');
+        textarea.value = inviteUrl;
+        textarea.style.position = 'fixed';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch {
+        setCopied(false);
+      }
     }
   };
 
@@ -57,8 +72,9 @@ const InviteUrlModal: React.FC<InviteUrlModalProps> = ({ isOpen, onClose, planId
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[1000] flex justify-center items-center p-4 animate-modal-fade-in" onClick={onClose}>
-      <div className="glass-effect rounded-xl w-auto max-w-md min-w-[280px] mx-auto p-6 md:p-8 space-y-6 shadow-elevation-5 animate-modal-zoom-in flex flex-col" onClick={e => e.stopPropagation()}>
+    <ModalPortal>
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[1000] flex justify-center items-center p-4 animate-modal-fade-in" onClick={onClose}>
+        <div className="glass-effect rounded-xl w-auto max-w-md min-w-[280px] mx-auto p-6 md:p-8 space-y-6 shadow-elevation-5 animate-modal-zoom-in flex flex-col" onClick={e => e.stopPropagation()}>
         {/* ヘッダー */}
         <div className="modal-header mb-4 flex items-center space-x-3">
           <div className="modal-header-icon">
@@ -85,21 +101,13 @@ const InviteUrlModal: React.FC<InviteUrlModalProps> = ({ isOpen, onClose, planId
         {/* ボタン */}
         <div className="flex flex-row justify-end gap-3 pt-6">
           <button className="btn-text" onClick={onClose}>閉じる</button>
-          <button className="btn-primary min-w-[100px]" onClick={async () => {
-            try {
-              await navigator.clipboard.writeText(inviteUrl);
-              setCopied(true);
-              setTimeout(() => setCopied(false), 1500);
-            } catch (err) {
-              setCopied(false);
-              alert('コピーに失敗しました');
-            }
-          }} disabled={!inviteUrl}>
+          <button className="btn-primary min-w-[100px]" onClick={handleCopy} disabled={!inviteUrl}>
             {copied ? 'コピーしました！' : 'URLをコピー'}
           </button>
         </div>
+        </div>
       </div>
-    </div>
+    </ModalPortal>
   );
 };
 

--- a/src/components/ModalPortal.tsx
+++ b/src/components/ModalPortal.tsx
@@ -1,0 +1,13 @@
+import { createPortal } from 'react-dom';
+import React from 'react';
+
+interface ModalPortalProps {
+  children: React.ReactNode;
+}
+
+const ModalPortal: React.FC<ModalPortalProps> = ({ children }) => {
+  const root = document.getElementById('modal-root') || document.body;
+  return createPortal(children, root);
+};
+
+export default ModalPortal;

--- a/src/components/SharePlanModal.tsx
+++ b/src/components/SharePlanModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ModalPortal from './ModalPortal';
 
 interface SharePlanModalProps {
   isOpen: boolean;
@@ -20,8 +21,9 @@ const SharePlanModal: React.FC<SharePlanModalProps> = ({ isOpen, onClose, onShar
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[1000] flex justify-center items-center p-4 animate-modal-fade-in" onClick={onClose}>
-      <div className="glass-effect rounded-xl w-auto max-w-md min-w-[280px] mx-auto p-6 md:p-8 space-y-6 shadow-elevation-5 animate-modal-zoom-in flex flex-col" onClick={e => e.stopPropagation()}>
+    <ModalPortal>
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[1000] flex justify-center items-center p-4 animate-modal-fade-in" onClick={onClose}>
+        <div className="glass-effect rounded-xl w-auto max-w-md min-w-[280px] mx-auto p-6 md:p-8 space-y-6 shadow-elevation-5 animate-modal-zoom-in flex flex-col" onClick={e => e.stopPropagation()}>
         {/* ヘッダー */}
         <div className="modal-header mb-4 flex items-center space-x-3">
           <div className="modal-header-icon">
@@ -55,8 +57,9 @@ const SharePlanModal: React.FC<SharePlanModalProps> = ({ isOpen, onClose, onShar
             <span className="body">URLで招待</span>
           </button>
         </div>
+        </div>
       </div>
-    </div>
+    </ModalPortal>
   );
 };
 


### PR DESCRIPTION
## Summary
- specify region for callable Cloud Functions and frontend calls
- render modals via portal to avoid screen edge clipping
- use Clipboard API fallback when copying invite links
- use supported Node.js version for Cloud Functions

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run type-check` *(fails: many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f4e50caa083329eccf2d744841cab