### PR TITLE
Fix cloud functions node version

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": "22"
+        "node": "20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- downgrade Node engine to 20 for Firebase functions

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6563cac483329fde61ac09a96ba6