### PR TITLE
Fix active plan after invite

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -172,5 +172,10 @@ export const acceptInviteToken = onCall(async (request) => {
       joinedAt: admin.firestore.FieldValue.serverTimestamp(),
     },
   });
+  // 参加ユーザーの activePlanId を更新
+  await db.collection('users').doc(uid).set({
+    activePlanId: planDoc.id,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
   return { success: true, planId: planDoc.id };
 });


### PR DESCRIPTION
## Summary
- set activePlanId in user document when accepting invite token

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68803de4539c83329c5790cc3675547b