### PR TITLE
Fix active plan after invite

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -172,5 +172,10 @@ export const acceptInviteToken = onCall(async (request) => {
       joinedAt: admin.firestore.FieldValue.serverTimestamp(),
     },
   });
+  // 参加ユーザーの activePlanId を更新
+  await db.collection('users').doc(uid).set({
+    activePlanId: planDoc.id,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
   return { success: true, planId: planDoc.id };
 });

--- a/src/components/InviteAcceptPage.tsx
+++ b/src/components/InviteAcceptPage.tsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '../firebase';
 import { useAuth } from '../hooks/useAuth';
+import { usePlanStore } from '../store/planStore';
+import { setActivePlan } from '../services/storageService';
 
 const InviteAcceptPage: React.FC = () => {
   const { token } = useParams<{ token: string }>();
@@ -32,10 +34,16 @@ const InviteAcceptPage: React.FC = () => {
         if (data.alreadyMember) {
           setStatus('already');
           setMessage('すでにこのプランのメンバーです。');
+          usePlanStore.getState().unsubscribeFromPlan();
+          usePlanStore.getState().setPlan(null);
+          setActivePlan(data.planId ?? null);
           setTimeout(() => navigate('/', { replace: true }), 2000);
         } else if (data.success) {
           setStatus('success');
           setMessage('プランに参加しました！');
+          usePlanStore.getState().unsubscribeFromPlan();
+          usePlanStore.getState().setPlan(null);
+          setActivePlan(data.planId ?? null);
           setTimeout(() => navigate('/', { replace: true }), 2000);
         } else {
           setStatus('error');


### PR DESCRIPTION
## Summary
- set activePlanId in user document when accepting invite token
- clear current plan and activePlan after accepting an invite so that joined plan loads correctly

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68803de4539c83329c5790cc3675547b