### PR TITLE
Add external browser login guidance modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import SyncTestButton from './components/SyncTestButton';
 import SyncDebugButton from './components/SyncDebugButton';
 import { syncDebugUtils } from './utils/syncDebugUtils';
 import SharePlanModal from './components/SharePlanModal';
+import ExternalBrowserPrompt from './components/ExternalBrowserPrompt';
 
 // LoadScript用のライブラリを定数として定義
 const LIBRARIES: ('places')[] = ['places'];
@@ -236,6 +237,9 @@ function App() {
 
       {/* クラウド同期インジケータ */}
       <SyncStatusIndicator onSave={updateLastSavedTimestamp} />
+
+      {/* アプリ内ブラウザでログインできない場合の案内 */}
+      <ExternalBrowserPrompt />
 
       
     </LoadScript>

--- a/src/components/ExternalBrowserPrompt.tsx
+++ b/src/components/ExternalBrowserPrompt.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import ModalPortal from './ModalPortal';
+import { useBrowserPromptStore } from '../store/browserPromptStore';
+
+const ExternalBrowserPrompt: React.FC = () => {
+  const { showExternalBrowserPrompt, setShowExternalBrowserPrompt } = useBrowserPromptStore();
+
+  if (!showExternalBrowserPrompt) return null;
+
+  const handleClose = () => setShowExternalBrowserPrompt(false);
+  const currentUrl = window.location.href;
+
+  return (
+    <ModalPortal>
+      <div
+        className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[1000] flex justify-center items-center p-4"
+        onClick={handleClose}
+      >
+        <div
+          className="glass-effect rounded-xl w-auto max-w-md min-w-[280px] mx-auto p-6 md:p-8 space-y-6 shadow-elevation-5"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="space-y-4 text-center">
+            <p className="body text-system-secondary-label whitespace-normal">
+              Googleログインはアプリ内ブラウザではご利用いただけません。<br />
+              Chrome や Safari などの外部ブラウザでこのページを開いてください。
+            </p>
+            <input
+              type="text"
+              readOnly
+              value={currentUrl}
+              className="input text-center"
+              onClick={(e) => (e.currentTarget as HTMLInputElement).select()}
+            />
+          </div>
+          <div className="flex justify-end gap-3 pt-6">
+            <a
+              href={currentUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-primary min-w-[100px] text-center"
+            >
+              外部ブラウザで開く
+            </a>
+            <button className="btn-secondary min-w-[80px]" onClick={handleClose}>
+              閉じる
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+};
+
+export default ExternalBrowserPrompt;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,6 +9,7 @@ import {
 } from 'firebase/auth';
 import { create } from 'zustand';
 import { auth } from '../firebase';
+import { useBrowserPromptStore } from '../store/browserPromptStore';
 
 // アプリ内ブラウザを検出する関数
 const isInAppBrowser = (): boolean => {
@@ -39,16 +40,16 @@ export const useAuthStore = create<AuthState>((set) => ({
   setUser: (user) => set({ user }),
   signIn: async () => {
     const provider = new GoogleAuthProvider();
-    
-    // アプリ内ブラウザの場合はリダイレクト方式を使用
+
     if (isInAppBrowser()) {
-      console.log('アプリ内ブラウザを検出: リダイレクト認証を使用');
-      await signInWithRedirect(auth, provider);
-    } else {
-      // 通常のブラウザの場合はリダイレクト方式を使用（ポップアップの問題を回避）
-      console.log('通常のブラウザ: リダイレクト認証を使用');
-      await signInWithRedirect(auth, provider);
+      console.log('アプリ内ブラウザを検出: 外部ブラウザ案内を表示');
+      useBrowserPromptStore.getState().setShowExternalBrowserPrompt(true);
+      return;
     }
+
+    // 通常のブラウザではリダイレクト方式を使用（ポップアップの問題を回避）
+    console.log('通常のブラウザ: リダイレクト認証を使用');
+    await signInWithRedirect(auth, provider);
   },
   signOut: async () => {
     await firebaseSignOut(auth);

--- a/src/store/browserPromptStore.ts
+++ b/src/store/browserPromptStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface BrowserPromptState {
+  showExternalBrowserPrompt: boolean;
+  setShowExternalBrowserPrompt: (show: boolean) => void;
+}
+
+export const useBrowserPromptStore = create<BrowserPromptState>((set) => ({
+  showExternalBrowserPrompt: false,
+  setShowExternalBrowserPrompt: (show) => set({ showExternalBrowserPrompt: show }),
+}));


### PR DESCRIPTION
## Summary
- show a modal when login is triggered from an in-app browser
- modal now includes a link to open the page in an external browser

## Testing
- `npm run type-check` *(fails: Cannot find type definition file)*
- `npm run lint` *(fails: ESLint couldn't find config)*


------
https://chatgpt.com/codex/tasks/task_e_68804f8f2f7483328df17d498b0a0a0f