### PR TITLE
Handle in-app browser login failures

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -18,6 +18,9 @@ const isInAppBrowser = (): boolean => {
     userAgent.includes('line') ||
     userAgent.includes('instagram') ||
     userAgent.includes('facebook') ||
+    userAgent.includes('fbav') ||
+    userAgent.includes('fban') ||
+    userAgent.includes('fb_iab') ||
     userAgent.includes('twitter') ||
     userAgent.includes('whatsapp') ||
     userAgent.includes('telegram') ||
@@ -49,7 +52,14 @@ export const useAuthStore = create<AuthState>((set) => ({
 
     // 通常のブラウザではリダイレクト方式を使用（ポップアップの問題を回避）
     console.log('通常のブラウザ: リダイレクト認証を使用');
-    await signInWithRedirect(auth, provider);
+    try {
+      await signInWithRedirect(auth, provider);
+    } catch (error) {
+      console.error('リダイレクト認証開始に失敗:', error);
+      // 何らかの理由でリダイレクトが開始できなかった場合も
+      // 外部ブラウザで開き直すよう案内する
+      useBrowserPromptStore.getState().setShowExternalBrowserPrompt(true);
+    }
   },
   signOut: async () => {
     await firebaseSignOut(auth);


### PR DESCRIPTION
## Summary
- widen detection of in-app browsers
- show external browser prompt if sign-in redirect fails

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails to compile: cannot find modules / implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880680a95548332b0d019f8b5cdf569