### PR TITLE
Handle in-app browser login failures

### DIFF
--- a/src/components/InviteAcceptPage.tsx
+++ b/src/components/InviteAcceptPage.tsx
@@ -7,6 +7,7 @@ import { usePlanStore } from '../store/planStore';
 import { usePlacesStore } from '../store/placesStore';
 import { useLabelsStore } from '../store/labelsStore';
 import { setActivePlan } from '../services/storageService';
+import ExternalBrowserPrompt from './ExternalBrowserPrompt';
 
 const InviteAcceptPage: React.FC = () => {
   const { token } = useParams<{ token: string }>();
@@ -92,8 +93,9 @@ const InviteAcceptPage: React.FC = () => {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-white z-[2000]">
-      <div className="glass-effect rounded-2xl max-w-md w-full p-8 shadow-lg text-center space-y-6">
+    <>
+      <div className="fixed inset-0 flex items-center justify-center bg-white z-[2000]">
+        <div className="glass-effect rounded-2xl max-w-md w-full p-8 shadow-lg text-center space-y-6">
         <h2 className="headline text-system-label">プランに参加</h2>
         {status === 'pending' && <div className="text-system-secondary-label">{message || '処理中...'}</div>}
         {status === 'auth' && (
@@ -111,8 +113,10 @@ const InviteAcceptPage: React.FC = () => {
         {status === 'error' && (
           <div className="text-system-secondary-label text-red-500">{message}</div>
         )}
+        </div>
       </div>
-    </div>
+      <ExternalBrowserPrompt />
+    </>
   );
 };
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -18,6 +18,9 @@ const isInAppBrowser = (): boolean => {
     userAgent.includes('line') ||
     userAgent.includes('instagram') ||
     userAgent.includes('facebook') ||
+    userAgent.includes('fbav') ||
+    userAgent.includes('fban') ||
+    userAgent.includes('fb_iab') ||
     userAgent.includes('twitter') ||
     userAgent.includes('whatsapp') ||
     userAgent.includes('telegram') ||
@@ -49,7 +52,14 @@ export const useAuthStore = create<AuthState>((set) => ({
 
     // 通常のブラウザではリダイレクト方式を使用（ポップアップの問題を回避）
     console.log('通常のブラウザ: リダイレクト認証を使用');
-    await signInWithRedirect(auth, provider);
+    try {
+      await signInWithRedirect(auth, provider);
+    } catch (error) {
+      console.error('リダイレクト認証開始に失敗:', error);
+      // 何らかの理由でリダイレクトが開始できなかった場合も
+      // 外部ブラウザで開き直すよう案内する
+      useBrowserPromptStore.getState().setShowExternalBrowserPrompt(true);
+    }
   },
   signOut: async () => {
     await firebaseSignOut(auth);


### PR DESCRIPTION
## Summary
- widen detection of in-app browsers
- show external browser prompt if sign-in redirect fails
- show same prompt when accepting invites via in-app browser

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails to compile: numerous missing types)*

------
https://chatgpt.com/codex/tasks/task_e_6880680a95548332b0d019f8b5cdf569