### PR TITLE
Fix label deserialization

### DIFF
--- a/src/store/labelsStore.ts
+++ b/src/store/labelsStore.ts
@@ -27,6 +27,15 @@ export const useLabelsStore = create<LabelsState>((set, get) => ({
   setOnLabelDeleted: (callback) => set({ onLabelDeleted: callback }),
   addLabel: (partial) =>
     set((s) => {
+      // CHANGELOG [1.4.24] 参照: 不正な `lat`/`lng` フィールドを許容し、
+      // `position` へ正規化する。
+      const { lat, lng, ...rest } = partial as any;
+      const position =
+        partial.position ??
+        (lat !== undefined && lng !== undefined
+          ? { lat, lng }
+          : undefined);
+
       const newLabel = {
         width: 120,
         height: 40,
@@ -34,7 +43,8 @@ export const useLabelsStore = create<LabelsState>((set, get) => ({
         fontSize: 14,
         fontFamily: 'sans-serif',
         status: 'new', // 新規作成時は'new'ステータス
-        ...partial,
+        ...rest,
+        position,
         id: uuidv4(),
         createdAt: new Date(),
         updatedAt: new Date(),

--- a/src/utils/planSerializer.ts
+++ b/src/utils/planSerializer.ts
@@ -32,5 +32,18 @@ export function serializePlan(plan: TravelPlan): string {
 }
 
 export function deserializePlan(json: string): TravelPlan {
-  return JSON.parse(json, dateReviver) as TravelPlan;
-} 
+  const plan = JSON.parse(json, dateReviver) as TravelPlan;
+
+  // CHANGELOG [1.4.24] 参照: 過去バージョンでは MapLabel の位置情報が
+  // { lat: number, lng: number } として保存されていた。旧データを
+  // 読み込んだ際に正しい `position` オブジェクトへ変換する。
+  plan.labels?.forEach((label: any) => {
+    if (!label.position && label.lat !== undefined && label.lng !== undefined) {
+      label.position = { lat: label.lat, lng: label.lng };
+    }
+    delete label.lat;
+    delete label.lng;
+  });
+
+  return plan;
+}


### PR DESCRIPTION
## Summary
- normalize legacy label schema in `deserializePlan`
- ensure `addLabel` handles deprecated lat/lng fields

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run type-check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68817a91c6fc8332a5ea87108533e0be